### PR TITLE
feat(WebApi, Application) Response and In-Memory Caching via Mediator

### DIFF
--- a/src/Application/CQRS/Caching/ICachedQuery.cs
+++ b/src/Application/CQRS/Caching/ICachedQuery.cs
@@ -1,0 +1,16 @@
+﻿using MediatR;
+
+namespace Ticketing.Application.CQRS.Caching;
+
+internal interface ICachedQuery<TResponse> : ICachedQuery, IRequest<TResponse>
+{
+}
+
+internal interface ICachedQuery
+{
+    public string CacheKey { get; }
+
+    public TimeSpan? AbsoluteExpiration { get; }
+
+    public TimeSpan? SlidingExpiration { get; }
+}

--- a/src/Application/Caching/Behavior/QueryCachingPipelineBehavior.cs
+++ b/src/Application/Caching/Behavior/QueryCachingPipelineBehavior.cs
@@ -1,0 +1,32 @@
+﻿using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Ticketing.Application.CQRS.Caching;
+using Ticketing.Domain.Exceptions;
+
+namespace Ticketing.Application.Caching
+{
+    internal class QueryCachingPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : ICachedQuery<TResponse>
+    {
+        private readonly IMemoryCache _cache;
+
+        public QueryCachingPipelineBehavior(IMemoryCache cache)
+        {
+            this._cache = cache;
+        }
+
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            TResponse? result = await this._cache.GetOrCreateAsync(request.CacheKey, cacheEntry =>
+            {
+                cacheEntry.SetSize(1)
+                    .SetAbsoluteExpiration(request.AbsoluteExpiration ?? TimeSpan.FromSeconds(90))
+                    .SetSlidingExpiration(request.SlidingExpiration ?? TimeSpan.FromSeconds(15));
+
+                return next();
+            });
+
+            return result ?? throw new NotFoundException("Cached response wasn't found!");
+        }
+    }
+}

--- a/src/Application/Caching/CacheKeyNames.cs
+++ b/src/Application/Caching/CacheKeyNames.cs
@@ -1,0 +1,33 @@
+﻿using Ticketing.Domain.Entities.Event;
+
+namespace Ticketing.Application.Caching
+{
+    internal class CacheKeyNames
+    {
+        /// <summary>
+        /// Template key name formatted by event id (0) and section id {1}.
+        /// </summary>
+        public const string EventSeatsByEventSection = "event-{0}-section-{1}-seats";
+
+        /// <summary>
+        /// Factory method to create EventSeats cache key from an event seat.
+        /// </summary>
+        /// <param name="seat"></param>
+        /// <returns></returns>
+        public static string GetEventSeatsCacheKeyFrom(EventSeat seat) =>
+            string.Format(EventSeatsByEventSection, seat.Row.Section.Event.Id, seat.Row.Section.Id);
+
+        /// <summary>
+        /// Factory method to create EventSeats cache key from event id and section id.
+        /// </summary>
+        /// <param name="seat"></param>
+        /// <returns></returns>
+        public static string GetEventSeatsCacheKeyFrom(int eventId, int sectionId) =>
+            string.Format(EventSeatsByEventSection, eventId, sectionId);
+
+        /// <summary>
+        /// Key name for events data.
+        /// </summary>
+        public const string Events = "events";
+    }
+}

--- a/src/Application/Caching/Invalidation/InvalidationNotificationHandler.cs
+++ b/src/Application/Caching/Invalidation/InvalidationNotificationHandler.cs
@@ -1,0 +1,45 @@
+﻿using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Ticketing.Application.Feature.Carting.BookCartSeats.Notifications;
+using Ticketing.Application.Feature.Carting.UpdateCartSeats.Notifications;
+using Ticketing.Domain.Entities.Event;
+
+namespace Ticketing.Application.Caching.Invalidation
+{
+    internal class InvalidationNotificationHandler :
+        INotificationHandler<SeatSelectedNotification>,
+        INotificationHandler<SeatsBookedNotification>
+    {
+        private readonly IMemoryCache _cache;
+
+        public InvalidationNotificationHandler(IMemoryCache cache)
+        {
+            this._cache = cache;
+        }
+
+        public Task Handle(SeatSelectedNotification notification, CancellationToken cancellationToken)
+        {
+            this.InvalidateEventCache(notification.Seat);
+
+            return Task.CompletedTask;
+        }
+
+        public Task Handle(SeatsBookedNotification notification, CancellationToken cancellationToken)
+        {
+            foreach (var seat in notification.Order.Seats)
+            {
+                this.InvalidateEventCache(seat);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void InvalidateEventCache(EventSeat seat)
+        {
+            string cacheKey = CacheKeyNames.GetEventSeatsCacheKeyFrom(seat);
+
+            this._cache.Remove(cacheKey);
+            this._cache.Remove(CacheKeyNames.Events);
+        }
+    }
+}

--- a/src/Application/DependencyRegistry.cs
+++ b/src/Application/DependencyRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Ticketing.Application.Caching;
 
 namespace Ticketing.Application;
 
@@ -7,7 +8,15 @@ public static class DependencyRegistry
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
         services.AddMediatR(configuration =>
-            configuration.RegisterServicesFromAssemblyContaining(typeof(DependencyRegistry)));
+            configuration
+                .RegisterServicesFromAssemblyContaining(typeof(DependencyRegistry))
+                .AddOpenBehavior(typeof(QueryCachingPipelineBehavior<,>))
+        );
+
+        services.AddMemoryCache(options =>
+        {
+            options.SizeLimit = 1024;
+        });
 
         return services;
     }

--- a/src/Application/Feature/Carting/BookCartSeats/Notifications/SeatsBookedNotification.cs
+++ b/src/Application/Feature/Carting/BookCartSeats/Notifications/SeatsBookedNotification.cs
@@ -1,0 +1,17 @@
+﻿using MediatR;
+using Ticketing.Domain.Entities.Ordering;
+
+namespace Ticketing.Application.Feature.Carting.BookCartSeats.Notifications;
+
+/// <summary>
+/// Notification message over booked seats.
+/// </summary>
+internal class SeatsBookedNotification : INotification
+{
+    public SeatsBookedNotification(Order order)
+    {
+        this.Order = order;
+    }
+
+    public Order Order { get; }
+}

--- a/src/Application/Feature/Carting/RemoveCartSeat/RemoveCartSeatCommandHandler.cs
+++ b/src/Application/Feature/Carting/RemoveCartSeat/RemoveCartSeatCommandHandler.cs
@@ -29,10 +29,10 @@ public class RemoveCartSeatCommandHandler : ICommandHandler<RemoveCartSeatComman
     /// <exception cref="NotImplementedException"></exception>
     public async Task Handle(RemoveCartSeatCommand request, CancellationToken cancellationToken)
     {
-        var cart = await GetCartAsync(request, cancellationToken);
+        var cart = await this.GetCartAsync(request, cancellationToken);
         var seat = GetSeat(request, cart);
 
-        cart.Seats.Remove(seat);
+        cart.Remove(seat);
 
         await this._unitOfWork.SaveChanges(cancellationToken);
     }

--- a/src/Application/Feature/Carting/UpdateCartSeats/Notifications/SeatSelectedNotification.cs
+++ b/src/Application/Feature/Carting/UpdateCartSeats/Notifications/SeatSelectedNotification.cs
@@ -1,0 +1,17 @@
+﻿using MediatR;
+using Ticketing.Domain.Entities.Event;
+
+namespace Ticketing.Application.Feature.Carting.UpdateCartSeats.Notifications;
+
+/// <summary>
+/// Notification message over the selected event seat.
+/// </summary>
+internal class SeatSelectedNotification : INotification
+{
+    public SeatSelectedNotification(EventSeat seat)
+    {
+        this.Seat = seat;
+    }
+
+    public EventSeat Seat { get; init; }
+}

--- a/src/Application/Feature/Event/Requests/EventSeatsBySectionRequest.cs
+++ b/src/Application/Feature/Event/Requests/EventSeatsBySectionRequest.cs
@@ -1,6 +1,14 @@
-﻿using MediatR;
+﻿using Ticketing.Application.Caching;
+using Ticketing.Application.CQRS.Caching;
 using Ticketing.Application.Feature.Event.Response;
 
 namespace Ticketing.Application.Feature.Event.Requests;
 
-public record EventSeatsBySectionRequest(int EventId, int SectionId) : IRequest<EventSeatsResponse>;
+public record EventSeatsBySectionRequest(int EventId, int SectionId) : ICachedQuery<EventSeatsResponse>
+{
+    public string CacheKey => CacheKeyNames.GetEventSeatsCacheKeyFrom(this.EventId, this.SectionId);
+
+    public TimeSpan? AbsoluteExpiration => default;
+
+    public TimeSpan? SlidingExpiration => default;
+}

--- a/src/Application/Feature/Event/Requests/EventsRequest.cs
+++ b/src/Application/Feature/Event/Requests/EventsRequest.cs
@@ -1,6 +1,14 @@
-﻿using MediatR;
+﻿using Ticketing.Application.Caching;
+using Ticketing.Application.CQRS.Caching;
 using Ticketing.Application.Feature.Event.Response;
 
 namespace Ticketing.Application.Feature.Event.Requests;
 
-public record EventsRequest() : IRequest<EventsResponse>;
+public record EventsRequest() : ICachedQuery<EventsResponse>
+{
+    public string CacheKey => CacheKeyNames.Events;
+
+    public TimeSpan? AbsoluteExpiration => default;
+
+    public TimeSpan? SlidingExpiration => default;
+}

--- a/src/Application/Ticketing.Application.csproj
+++ b/src/Application/Ticketing.Application.csproj
@@ -7,11 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="CQRS\Behavior\**" />
+    <EmbeddedResource Remove="CQRS\Behavior\**" />
+    <None Remove="CQRS\Behavior\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Domain\Ticketing.Domain.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Riok.Mapperly" Version="3.3.0" />
   </ItemGroup>
 

--- a/src/Domain/Entities/Cart.cs
+++ b/src/Domain/Entities/Cart.cs
@@ -17,6 +17,13 @@ public class Cart
         get => this.Seats?.Sum(seat => seat.Price?.Amount) ?? 0;
     }
 
+    public void Add(EventSeat seat)
+    {
+        seat.Status = SeatStatusOption.Selected;
+
+        this.Seats.Add(seat);
+    }
+
     public void BookSeats()
     {
         foreach (var seat in this.Seats)
@@ -28,5 +35,12 @@ public class Cart
     public void Clear()
     {
         this.Seats.Clear();
+    }
+
+    public void Remove(EventSeat seat)
+    {
+        seat.Status = SeatStatusOption.Available;
+
+        this.Seats.Remove(seat);
     }
 }

--- a/src/Domain/Entities/Payments/Payment.cs
+++ b/src/Domain/Entities/Payments/Payment.cs
@@ -10,7 +10,7 @@ public class Payment
     public Guid PaymentGuid { get; set; }
     public decimal Price { get; set; }
     public PaymentStatusOption Status { get; set; }
-    public virtual Order? Order { get; set; }
+    public virtual Order Order { get; set; }
 
     /// <summary>
     /// Updates payment status and moves all the seats related to a payment to the sold state.

--- a/src/Domain/Enums/SeatStatusOption.cs
+++ b/src/Domain/Enums/SeatStatusOption.cs
@@ -3,6 +3,7 @@
 public enum SeatStatusOption
 {
     Available = 0,
+    Selected,
     Booked,
     Sold
 }

--- a/src/WebApi/Caching/CacheProfileRegister.cs
+++ b/src/WebApi/Caching/CacheProfileRegister.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Ticketing.WebApi.Caching
+{
+    public static class CacheProfileRegister
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public const string EventsProfileName = "CacheEvents";
+
+        /// <summary>
+        /// Extension method to control response cache to ‘Event’ resource endpoints (/events/*) using request (HTTP) caching,
+        /// allow client applications perform cache management on their side and avoid making additional requests to the server with no need.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static MvcOptions AddCacheProfileEvents(this MvcOptions options)
+        {
+            CacheProfile profile = new()
+            {
+                Duration = TimeSpan.FromSeconds(15).Seconds,
+                Location = ResponseCacheLocation.Client,
+                NoStore = false,
+            };
+
+            options.CacheProfiles.Add(EventsProfileName, profile);
+
+            return options;
+        }
+    }
+}

--- a/src/WebApi/Events/EventController.cs
+++ b/src/WebApi/Events/EventController.cs
@@ -1,11 +1,11 @@
 ﻿using System.Net.Mime;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Ticketing.Application.Feature.Event;
 using Ticketing.Application.Feature.Event.Requests;
 using Ticketing.Application.Feature.Event.Response;
 using Ticketing.WebApi.Events.Mappers;
 using Ticketing.WebApi.Events.Models;
+using Ticketing.WebApi.Caching;
 
 namespace Ticketing.WebApi.Events;
 
@@ -14,6 +14,7 @@ namespace Ticketing.WebApi.Events;
 /// </summary>
 [ApiController]
 [Route("api/events")]
+[ResponseCache(CacheProfileName = CacheProfileRegister.EventsProfileName)]
 public class EventController(IMediator mediator) : ControllerBase
 {
     /// <summary>

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -4,11 +4,14 @@ using Ticketing.Application;
 using Ticketing.DataAccess.DependencyInjection;
 using Ticketing.WebApi.Startup;
 using Ticketing.WebApi.Startup.ExceptionHandlers;
+using Ticketing.WebApi.Caching;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddResponseCaching();
+builder.Services.AddControllers(options => options.AddCacheProfileEvents());
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddExceptionHandler<NotFoundExceptionHandler>();
 
@@ -35,6 +38,8 @@ else
 
 app.UseHttpsRedirection();
 app.UseAuthorization();
+
+app.UseResponseCaching();
 app.MapControllers();
 
 app.Run();

--- a/tests/Ticketing.DataAccess.UnitTests/Repositories/CartRepositoryTests.cs
+++ b/tests/Ticketing.DataAccess.UnitTests/Repositories/CartRepositoryTests.cs
@@ -10,7 +10,8 @@ public class CartRepositoryTests : RepositoryTestsBase
     private readonly static Guid _cartId = Guid.NewGuid();
     private readonly CartRepository _cartRepository;
 
-    public CartRepositoryTests(LocalDbTestDatabaseFixture databaseFixture) : base(databaseFixture)
+    public CartRepositoryTests(LocalDbTestDatabaseFixture databaseFixture)
+        : base(databaseFixture)
     {
         this._cartRepository = new CartRepository(this._context);
     }

--- a/tests/Ticketing.WebAPI.IntegrationTests/Events/EventsTests.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Events/EventsTests.cs
@@ -54,7 +54,7 @@ public class EventsTests : IntegrationTestsBase
 
     private EventSeat InitializeDatabaseWithEventSeats()
     {
-        using DataContext dataContext = this.GetDbContext();
+        using DataContext dataContext = this._factory.GetDbContext();
         var eventSeat = EventSeatDataSeed.Seed();
 
         dataContext.Add(eventSeat);

--- a/tests/Ticketing.WebAPI.IntegrationTests/Events/EventsTests.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Events/EventsTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using Ticketing.DataAccess;
+using Ticketing.Domain.Entities.Event;
+using Ticketing.Tests.Core.DataSeeds.EventRelated;
+using Ticketing.WebApi.IntegrationTests.Fixtures;
+
+namespace Ticketing.WebApi.IntegrationTests.Events;
+
+public class EventsTests : IntegrationTestsBase
+{
+    private const string ResourceRoot = "api/events";
+
+    public EventsTests(WebApplicationFixture applicationFixture)
+        : base(applicationFixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetEvents_ResponseCacheControl_PrivateMaxAge15()
+    {
+        CacheControlHeaderValue expectedCacheControl = new()
+        {
+            MaxAge = TimeSpan.FromSeconds(15),
+            Private = true
+        };
+
+        var serverResult = await this._client.GetAsync(ResourceRoot);
+
+        Assert.Equal(HttpStatusCode.OK, serverResult.StatusCode);
+        Assert.Equal(expectedCacheControl, serverResult.Headers.CacheControl);
+    }
+
+    [Fact]
+    public async Task GetSeats_ResponseCacheControl_PrivateMaxAge15()
+    {
+        var eventSeat = this.InitializeDatabaseWithEventSeats();
+        var eventId = eventSeat.Row.Section.Event.Id;
+        var sectionId = eventSeat.Row.Section.Id;
+
+        var resourcePath = $"{ResourceRoot}/{eventId}/sections/{sectionId}/seats";
+
+        CacheControlHeaderValue expectedCacheControl = new()
+        {
+            MaxAge = TimeSpan.FromSeconds(15),
+            Private = true
+        };
+
+        var serverResult = await this._client.GetAsync(resourcePath);
+
+        Assert.Equal(HttpStatusCode.OK, serverResult.StatusCode);
+        Assert.Equal(expectedCacheControl, serverResult.Headers.CacheControl);
+    }
+
+    private EventSeat InitializeDatabaseWithEventSeats()
+    {
+        using DataContext dataContext = this.GetDbContext();
+        var eventSeat = EventSeatDataSeed.Seed();
+
+        dataContext.Add(eventSeat);
+        dataContext.SaveChanges();
+
+        return eventSeat;
+    }
+}

--- a/tests/Ticketing.WebAPI.IntegrationTests/Fixtures/WebApplicationFixture.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Fixtures/WebApplicationFixture.cs
@@ -1,14 +1,36 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Ticketing.DataAccess;
 using WebApiApplication = Ticketing.WebApi.Program;
 
 namespace Ticketing.WebApi.IntegrationTests.Fixtures
 {
     public class WebApplicationFixture : WebApplicationFactory<WebApiApplication>
     {
+        public WebApplicationFixture()
+        {
+            this.InitializeDatabase();
+        }
+
+        public DataContext GetDbContext()
+        {
+            IServiceScope scope = this.Services.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+
+            return scopedServices.GetRequiredService<DataContext>();
+        }
+
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.UseEnvironment("Local-QA");
             builder.UseSetting("Database:ConnectionString", "Server=(localdb)\\mssqllocaldb;Database=Ticketing;Trusted_Connection=True;");
+        }
+
+        protected void InitializeDatabase()
+        {
+            using DataContext dataContext = this.GetDbContext();
+
+            dataContext.Database.EnsureDeleted();
+            dataContext.Database.EnsureCreated();
         }
     }
 }

--- a/tests/Ticketing.WebAPI.IntegrationTests/Fixtures/WebApplicationFixture.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Fixtures/WebApplicationFixture.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
 using WebApiApplication = Ticketing.WebApi.Program;
 
-namespace Ticketing.WebAPI.IntegrationTests.Fixtures
+namespace Ticketing.WebApi.IntegrationTests.Fixtures
 {
     public class WebApplicationFixture : WebApplicationFactory<WebApiApplication>
     {

--- a/tests/Ticketing.WebAPI.IntegrationTests/IntegrationTestsBase.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/IntegrationTestsBase.cs
@@ -1,0 +1,34 @@
+﻿using Ticketing.DataAccess;
+using Ticketing.WebApi.IntegrationTests.Fixtures;
+
+namespace Ticketing.WebApi.IntegrationTests;
+
+public class IntegrationTestsBase : IClassFixture<WebApplicationFixture>
+{
+    protected readonly HttpClient _client;
+    private readonly WebApplicationFixture _factory;
+
+    public IntegrationTestsBase(WebApplicationFixture applicationFixture)
+    {
+        this._factory = applicationFixture;
+        this._client = applicationFixture.CreateClient();
+
+        this.InitializeDatabase();
+    }
+
+    protected void InitializeDatabase()
+    {
+        using DataContext dataContext = this.GetDbContext();
+
+        dataContext.Database.EnsureDeleted();
+        dataContext.Database.EnsureCreated();
+    }
+
+    protected DataContext GetDbContext()
+    {
+        IServiceScope scope = this._factory.Services.CreateScope();
+        var scopedServices = scope.ServiceProvider;
+
+        return scopedServices.GetRequiredService<DataContext>();
+    }
+}

--- a/tests/Ticketing.WebAPI.IntegrationTests/IntegrationTestsBase.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/IntegrationTestsBase.cs
@@ -5,6 +5,9 @@ namespace Ticketing.WebApi.IntegrationTests;
 
 public class IntegrationTestsBase : IClassFixture<WebApplicationFixture>
 {
+    private static readonly object _lock = new();
+    private static bool _databaseInitialized;
+
     protected readonly HttpClient _client;
     private readonly WebApplicationFixture _factory;
 
@@ -13,7 +16,15 @@ public class IntegrationTestsBase : IClassFixture<WebApplicationFixture>
         this._factory = applicationFixture;
         this._client = applicationFixture.CreateClient();
 
-        this.InitializeDatabase();
+        lock (_lock)
+        {
+            if (_databaseInitialized)
+                return;
+
+            this.InitializeDatabase();
+
+            _databaseInitialized = true;
+        }
     }
 
     protected void InitializeDatabase()

--- a/tests/Ticketing.WebAPI.IntegrationTests/IntegrationTestsBase.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/IntegrationTestsBase.cs
@@ -1,45 +1,15 @@
-﻿using Ticketing.DataAccess;
-using Ticketing.WebApi.IntegrationTests.Fixtures;
+﻿using Ticketing.WebApi.IntegrationTests.Fixtures;
 
 namespace Ticketing.WebApi.IntegrationTests;
 
-public class IntegrationTestsBase : IClassFixture<WebApplicationFixture>
+public abstract class IntegrationTestsBase : IAssemblyFixture<WebApplicationFixture>
 {
-    private static readonly object _lock = new();
-    private static bool _databaseInitialized;
-
     protected readonly HttpClient _client;
-    private readonly WebApplicationFixture _factory;
+    protected readonly WebApplicationFixture _factory;
 
     public IntegrationTestsBase(WebApplicationFixture applicationFixture)
     {
         this._factory = applicationFixture;
         this._client = applicationFixture.CreateClient();
-
-        lock (_lock)
-        {
-            if (_databaseInitialized)
-                return;
-
-            this.InitializeDatabase();
-
-            _databaseInitialized = true;
-        }
-    }
-
-    protected void InitializeDatabase()
-    {
-        using DataContext dataContext = this.GetDbContext();
-
-        dataContext.Database.EnsureDeleted();
-        dataContext.Database.EnsureCreated();
-    }
-
-    protected DataContext GetDbContext()
-    {
-        IServiceScope scope = this._factory.Services.CreateScope();
-        var scopedServices = scope.ServiceProvider;
-
-        return scopedServices.GetRequiredService<DataContext>();
     }
 }

--- a/tests/Ticketing.WebAPI.IntegrationTests/Orders/OrderTests.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Orders/OrderTests.cs
@@ -96,7 +96,7 @@ public class OrderTests : IntegrationTestsBase
 
     private Cart InitializeDatabaseWithCart()
     {
-        using DataContext dataContext = this.GetDbContext();
+        using DataContext dataContext = this._factory.GetDbContext();
         var cart = CartDataSeed.Seed();
 
         dataContext.Add(cart);
@@ -107,7 +107,7 @@ public class OrderTests : IntegrationTestsBase
 
     private EventSeat InitializeDatabaseWithSeat()
     {
-        using DataContext dataContext = this.GetDbContext();
+        using DataContext dataContext = this._factory.GetDbContext();
         var seat = EventSeatDataSeed.Seed();
 
         dataContext.Add(seat);

--- a/tests/Ticketing.WebAPI.IntegrationTests/Orders/OrderTests.cs
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Orders/OrderTests.cs
@@ -4,26 +4,21 @@ using Ticketing.Domain.Entities;
 using Ticketing.Domain.Entities.Event;
 using Ticketing.Tests.Core.DataSeeds;
 using Ticketing.Tests.Core.DataSeeds.EventRelated;
+using Ticketing.WebApi.IntegrationTests.Fixtures;
 using Ticketing.WebApi.Models;
 using Ticketing.WebApi.Orders.Models;
-using Ticketing.WebAPI.IntegrationTests.Fixtures;
 
-namespace Ticketing.WebAPI.IntegrationTests.Orders;
+namespace Ticketing.WebApi.IntegrationTests.Orders;
 
-public class OrderTests : IClassFixture<WebApplicationFixture>
+public class OrderTests : IntegrationTestsBase
 {
     private const string EndpointTemplate = "api/orders/carts/{0}";
 
-    private readonly WebApplicationFixture _factory;
-    private readonly HttpClient _client;
     private Cart _testCart;
 
     public OrderTests(WebApplicationFixture webApplicationFactory)
+        : base(webApplicationFactory)
     {
-        this._factory = webApplicationFactory;
-        this._client = this._factory.CreateClient();
-
-        this.InitializeDatabase();
         this._testCart = this.InitializeDatabaseWithCart();
     }
 
@@ -99,14 +94,6 @@ public class OrderTests : IClassFixture<WebApplicationFixture>
         Assert.Equal($"Can't find the requested resource (/{uri}).", message);
     }
 
-    private void InitializeDatabase()
-    {
-        using DataContext dataContext = this.GetDbContext();
-
-        dataContext.Database.EnsureDeleted();
-        dataContext.Database.EnsureCreated();
-    }
-
     private Cart InitializeDatabaseWithCart()
     {
         using DataContext dataContext = this.GetDbContext();
@@ -127,13 +114,5 @@ public class OrderTests : IClassFixture<WebApplicationFixture>
         dataContext.SaveChanges();
 
         return seat;
-    }
-
-    private DataContext GetDbContext()
-    {
-        IServiceScope scope = this._factory.Services.CreateScope();
-        var scopedServices = scope.ServiceProvider;
-
-        return scopedServices.GetRequiredService<DataContext>();
     }
 }

--- a/tests/Ticketing.WebAPI.IntegrationTests/Ticketing.WebAPI.IntegrationTests.csproj
+++ b/tests/Ticketing.WebAPI.IntegrationTests/Ticketing.WebAPI.IntegrationTests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+	  <PackageReference Include="xunit.assemblyfixture" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Task 1:
 Implement caching logic for Event resource. It can be either In-Memory or Distributed by your choice (discuss with mentor if you have hesitations). Modify POST/PUT endpoints of Order resource to invalidate Event cache. Leave DELETE endpoints untouched for testing needs.

## Task 2:
In addition to task 1 cover ‘Event’ resource endpoints (/events/*) using request (HTTP) caching allow client applications perform cache management on their side and avoid making additional requests to the server with no need.
