### PR TITLE
feat(Codespace): setup dev containers for remote development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:1-8.0
+
+# Install SQL Tools: SQLPackage and sqlcmd
+COPY mssql/installSQLtools.sh installSQLtools.sh
+RUN bash ./installSQLtools.sh \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet-mssql
+{
+	"name": "C# (.NET) and MS SQL",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/dotnet:2": {
+			"version": "8.0"
+		}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"mssql.connections": [
+					{
+						"server": "localhost,1433",
+						"database": "",
+						"authenticationType": "SqlLogin",
+						"user": "sa",
+						"password": "P@ssw0rd",
+						"emptyPasswordInput": false,
+						"savePassword": false,
+						"profileName": "mssql-container"
+					}
+				]
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-dotnettools.csharp",
+				"ms-mssql.mssql"
+			]
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [5000, 5001],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+	// postCreateCommand.sh parameters: $1=SA password, $2=dacpac path, $3=sql script(s) path
+	"postCreateCommand": "bash .devcontainer/mssql/postCreateCommand.sh 'P@ssw0rd' './bin/Debug/' './.devcontainer/mssql/'"
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,15 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet-mssql
 {
-	"name": "C# (.NET) and MS SQL",
+	"name": "C# (.NET) & MS SQL & Rabbit MQ",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/dotnet:2": {
-			"version": "8.0"
-		}
+		"ghcr.io/devcontainers/features/dotnet:2": {},
+		"ghcr.io/itsmechlark/features/rabbitmq-server:1": {}
 	},
-
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -22,7 +19,7 @@
 				"mssql.connections": [
 					{
 						"server": "localhost,1433",
-						"database": "",
+						"database": "Ticketing",
 						"authenticationType": "SqlLogin",
 						"user": "sa",
 						"password": "P@ssw0rd",
@@ -35,17 +32,21 @@
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-dotnettools.csharp",
-				"ms-mssql.mssql"
+				"ms-mssql.mssql",
+				"ms-dotnettools.csdevkit"
 			]
 		}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [5000, 5001],
+	"forwardPorts": [
+		5108, // ticketing service http port 
+		15672 // rabbit MQ admin port
+	],
 	// "portsAttributes": {
-	//		"5001": {
-	//			"protocol": "https"
-	//		}
-	// }
+	// 	"5108": {
+	// 		"protocol": "https"
+	// 	}
+	// },
 	// postCreateCommand.sh parameters: $1=SA password, $2=dacpac path, $3=sql script(s) path
 	"postCreateCommand": "bash .devcontainer/mssql/postCreateCommand.sh 'P@ssw0rd' './bin/Debug/' './.devcontainer/mssql/'"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,14 +18,15 @@
 			"settings": {
 				"mssql.connections": [
 					{
-						"server": "localhost,1433",
+						"server": "ticketing-db,1433",
 						"database": "Ticketing",
 						"authenticationType": "SqlLogin",
 						"user": "sa",
 						"password": "P@ssw0rd",
 						"emptyPasswordInput": false,
 						"savePassword": false,
-						"profileName": "mssql-container"
+						"profileName": "mssql-container",
+						"trustServerCertificate": true
 					}
 				]
 			},
@@ -33,14 +34,16 @@
 			"extensions": [
 				"ms-dotnettools.csharp",
 				"ms-mssql.mssql",
-				"ms-dotnettools.csdevkit"
+				"ms-dotnettools.csdevkit",
+				"ms-azuretools.vscode-docker"
 			]
 		}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		5108, // ticketing service http port 
-		15672 // rabbit MQ admin port
+		15672,// rabbit MQ admin port
+		1433 //  forward MSSQL locally
 	],
 	// "portsAttributes": {
 	// 	"5108": {
@@ -48,7 +51,7 @@
 	// 	}
 	// },
 	// postCreateCommand.sh parameters: $1=SA password, $2=dacpac path, $3=sql script(s) path
-	"postCreateCommand": "bash .devcontainer/mssql/postCreateCommand.sh 'P@ssw0rd' './bin/Debug/' './.devcontainer/mssql/'"
+	"postCreateCommand": "bash .devcontainer/mssql/postCreateCommand.sh 'P@ssw0rd' './bin/Debug/' './.devcontainer/mssql/' 'ticketing-db,1433'"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,8 +41,9 @@
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
+		5109, // ticketing service https port 
 		5108, // ticketing service http port 
-		15672,// rabbit MQ admin port
+		15672, // rabbit MQ admin port
 		1433 //  forward MSSQL locally
 	],
 	// "portsAttributes": {
@@ -51,7 +52,10 @@
 	// 	}
 	// },
 	// postCreateCommand.sh parameters: $1=SA password, $2=dacpac path, $3=sql script(s) path
-	"postCreateCommand": "bash .devcontainer/mssql/postCreateCommand.sh 'P@ssw0rd' './bin/Debug/' './.devcontainer/mssql/' 'ticketing-db,1433'"
+	"postCreateCommand": {
+		"sql": "bash .devcontainer/mssql/postCreateCommand.sh 'P@ssw0rd' './bin/Debug/' './.devcontainer/mssql/' 'ticketing-db,1433'",
+		"dev-cert": "dotnet dev-certs https"
+	}
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    # user: root
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    restart: unless-stopped
+    environment:
+      SA_PASSWORD: P@ssw0rd
+      ACCEPT_EULA: Y
+
+    # Add "forwardPorts": ["1433"] to **devcontainer.json** to forward MSSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,20 +13,42 @@ services:
     command: sleep infinity
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+    # network_mode: service:db
 
     # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     # user: root
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
     # (Adding the "ports" property to this file will not forward from a Codespace.)
+    depends_on:
+      - ticketing-db
+      - ticketing-mq
 
-  db:
+    networks:
+      - message-queue
+      - data-base
+
+  ticketing-db:
     image: mcr.microsoft.com/mssql/server:2019-latest
     restart: unless-stopped
     environment:
       SA_PASSWORD: P@ssw0rd
       ACCEPT_EULA: Y
+    networks:
+      - data-base
 
     # Add "forwardPorts": ["1433"] to **devcontainer.json** to forward MSSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  ticketing-mq:
+    image: rabbitmq:3.12-management-alpine
+    restart: unless-stopped
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - message-queue
+
+networks:
+  message-queue:
+  data-base:

--- a/.devcontainer/mssql/installSQLtools.sh
+++ b/.devcontainer/mssql/installSQLtools.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Installing mssql-tools"
+curl -sSL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+CODENAME=$(lsb_release -cs)
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+apt-get update
+ACCEPT_EULA=Y apt-get -y install unixodbc-dev msodbcsql17 libunwind8 mssql-tools
+
+echo "Installing sqlpackage"
+curl -sSL -o sqlpackage.zip "https://aka.ms/sqlpackage-linux"
+mkdir /opt/sqlpackage
+unzip sqlpackage.zip -d /opt/sqlpackage 
+rm sqlpackage.zip
+chmod a+x /opt/sqlpackage/sqlpackage

--- a/.devcontainer/mssql/postCreateCommand.sh
+++ b/.devcontainer/mssql/postCreateCommand.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+dacpac="false"
+sqlfiles="false"
+SApassword=$1
+dacpath=$2
+sqlpath=$3
+
+echo "SELECT * FROM SYS.DATABASES" | dd of=testsqlconnection.sql
+for i in {1..60};
+do
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SApassword -d master -i testsqlconnection.sql > /dev/null
+    if [ $? -eq 0 ]
+    then
+        echo "SQL server ready"
+        break
+    else
+        echo "Not ready yet..."
+        sleep 1
+    fi
+done
+rm testsqlconnection.sql
+
+for f in $dacpath/*
+do
+    if [ $f == $dacpath/*".dacpac" ]
+    then
+        dacpac="true"
+        echo "Found dacpac $f"
+    fi
+done
+
+for f in $sqlpath/*
+do
+    if [ $f == $sqlpath/*".sql" ]
+    then
+        sqlfiles="true"
+        echo "Found SQL file $f"
+    fi
+done
+
+if [ $sqlfiles == "true" ]
+then
+    for f in $sqlpath/*
+    do
+        if [ $f == $sqlpath/*".sql" ]
+        then
+            echo "Executing $f"
+            /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SApassword -d master -i $f
+        fi
+    done
+fi
+
+if [ $dacpac == "true" ] 
+then
+    for f in $dacpath/*
+    do
+        if [ $f == $dacpath/*".dacpac" ]
+        then
+            dbname=$(basename $f ".dacpac")
+            echo "Deploying dacpac $f"
+            /opt/sqlpackage/sqlpackage /Action:Publish /SourceFile:$f /TargetServerName:localhost /TargetDatabaseName:$dbname /TargetUser:sa /TargetPassword:$SApassword
+        fi
+    done
+fi

--- a/.devcontainer/mssql/postCreateCommand.sh
+++ b/.devcontainer/mssql/postCreateCommand.sh
@@ -4,11 +4,12 @@ sqlfiles="false"
 SApassword=$1
 dacpath=$2
 sqlpath=$3
+sqlhost=$4
 
 echo "SELECT * FROM SYS.DATABASES" | dd of=testsqlconnection.sql
 for i in {1..60};
 do
-    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SApassword -d master -i testsqlconnection.sql > /dev/null
+    /opt/mssql-tools/bin/sqlcmd -S $sqlhost -U sa -P $SApassword -d master -i testsqlconnection.sql > /dev/null
     if [ $? -eq 0 ]
     then
         echo "SQL server ready"
@@ -45,7 +46,7 @@ then
         if [ $f == $sqlpath/*".sql" ]
         then
             echo "Executing $f"
-            /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SApassword -d master -i $f
+            /opt/mssql-tools/bin/sqlcmd -S $sqlhost -U sa -P $SApassword -d master -i $f
         fi
     done
 fi
@@ -58,7 +59,7 @@ then
         then
             dbname=$(basename $f ".dacpac")
             echo "Deploying dacpac $f"
-            /opt/sqlpackage/sqlpackage /Action:Publish /SourceFile:$f /TargetServerName:localhost /TargetDatabaseName:$dbname /TargetUser:sa /TargetPassword:$SApassword
+            /opt/sqlpackage/sqlpackage /Action:Publish /SourceFile:$f /TargetServerName:$sqlhost /TargetDatabaseName:$dbname /TargetUser:sa /TargetPassword:$SApassword
         fi
     done
 fi

--- a/.devcontainer/mssql/setup.sql
+++ b/.devcontainer/mssql/setup.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE Ticketing;
+GO

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/WebApi/Properties/launchSettings.json
+++ b/src/WebApi/Properties/launchSettings.json
@@ -1,24 +1,16 @@
 {
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5108"
-    },
     "https": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORTS": "5109",
+        "ASPNETCORE_HTTP_PORTS": "5108"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "https://localhost:7141;http://localhost:5108"
+      "applicationUrl": "http://localhost:5108;https://localhost:5109"
     },
     "IIS Express": {
       "commandName": "IISExpress",

--- a/src/WebApi/appsettings.Development.json
+++ b/src/WebApi/appsettings.Development.json
@@ -6,12 +6,12 @@
     }
   },
 	"Database": {
-		"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=Ticketing;Trusted_Connection=True;",
+		"ConnectionString": "Server=ticketing-db;User=sa;Password=P@ssw0rd;Database=Ticketing;Trusted_Connection=True;",
 		"TimeoutSeconds": 30,
 		"RetryAttempts": 3,
 		"RetryDelaySeconds": 5
 	},
 	"MassageBroker": {
-		"ConnectionString": "amqp://guest:guest@localhost:5672/"
+		"ConnectionString": "amqp://guest:guest@ticketing-mq:5672/"
 	}
 }


### PR DESCRIPTION
The Visual Studio Code Dev Containers extension lets you use a container as a full-featured development environment. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set.

A [devcontainer.json file](https://code.visualstudio.com/docs/devcontainers/containers#_create-a-devcontainerjson-file) in your project tells VS Code how to access (or create) a development container with a well-defined tool and runtime stack. This container can be used to run an application or to separate tools, libraries, or runtimes needed for working with a codebase.